### PR TITLE
[HOTFIX] Desborde Footer

### DIFF
--- a/src/components/ui/nav/NavLinks.tsx
+++ b/src/components/ui/nav/NavLinks.tsx
@@ -17,7 +17,7 @@ export const NavLinks = ({
             className={`sm:flex 
                 ${
                     footer
-                        ? "flex justify-center items-center flex-col gap-0"
+                        ? "flex md:text-sm justify-center items-center flex-col gap-0"
                         : "hidden flex-row justify-evenly items-center gap-10"
                 } `}
         >


### PR DESCRIPTION
# Cambios
- Arregla el desborde del footer

## Antes
<img width="2556" height="472" alt="image" src="https://github.com/user-attachments/assets/9998e8f1-6bde-4731-8d61-5fab554451f9" />


## Despues
<img width="2540" height="470" alt="image" src="https://github.com/user-attachments/assets/f6e8768c-fba3-4ba8-b2cf-308a65a174f9" />
